### PR TITLE
fix: Makefile made more generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@ BUILD_DIR = build/debug
 CC = g++
 SRC_FILES = $(wildcard $(SRC_DIR)/*.cpp)
 OBJ_NAME = Chip8
-INCLUDE_PATHS = -I /opt/homebrew/Cellar/sdl2/2.30.9/include/ -I include
-LIBRARY_PATHS = -L /opt/homebrew/Cellar/sdl2/2.30.9/lib/
+INCLUDE_PATHS = $(shell sdl2-config --cflags) -Iinclude
+LIBRARY_PATHS = $(shell sdl2-config --libs)
 COMPILER_FLAGS = -Wall -std=c++11 -O0 -g
-LINKER_FLAGS = -lsdl2
 
 all: 
-	$(CC) $(COMPILER_FLAGS) $(LINKER_FLAGS) $(INCLUDE_PATHS) $(LIBRARY_PATHS) $(SRC_FILES) -o $(BUILD_DIR)/$(OBJ_NAME)
+	$(CC) $(COMPILER_FLAGS) $(INCLUDE_PATHS) $(SRC_FILES) $(LIBRARY_PATHS) -o $(BUILD_DIR)/$(OBJ_NAME)

--- a/include/audio.h
+++ b/include/audio.h
@@ -1,7 +1,7 @@
 #ifndef AUDIO_H
 #define AUDIO_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 class Audio
 {
@@ -12,7 +12,8 @@ public:
     {
         SDL_PauseAudioDevice(audioDevice, 0);
     }
-    void stopBeep() {
+    void stopBeep()
+    {
         SDL_PauseAudioDevice(audioDevice, 1);
     }
 

--- a/include/chip8.h
+++ b/include/chip8.h
@@ -1,7 +1,7 @@
 #ifndef CHIP8_H
 #define CHIP8_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <cstdint>
 #include <fstream>
 

--- a/include/event_handler.h
+++ b/include/event_handler.h
@@ -1,7 +1,7 @@
 #ifndef EVENT_HANDLER_H
 #define EVENT_HANDLER_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "chip8.h"
 #include "audio.h"
 

--- a/include/input.h
+++ b/include/input.h
@@ -1,7 +1,7 @@
 #ifndef INPUT_H
 #define INPUT_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 void handleKeyPress(SDL_Keycode key, bool isPressed, uint8_t *keypad);
 

--- a/include/sdl_utils.h
+++ b/include/sdl_utils.h
@@ -1,7 +1,7 @@
 #ifndef SDL_UTILS_H
 #define SDL_UTILS_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 bool initialiseSDL(SDL_Window *&window, SDL_Renderer *&renderer);
 void cleanupSDL(SDL_Window *window, SDL_Renderer *renderer);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "chip8.h"
 #include "audio.h"
 #include "input.h"

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -1,5 +1,5 @@
 #include "timer.h"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 void updateTimers(Chip8 &chip8, Audio &audio, double &lastTimerUpdate, const double MS_PER_TIMER)
 {


### PR DESCRIPTION
The Makefile now utilises `sdl2-config` to
determine the necessary flags for compilation.
Include paths now use `#include "SDL.h"` to
account for this.

Closes: #1